### PR TITLE
Transport credits/1.14

### DIFF
--- a/src/main/java/me/skorrloregaming/Server.java
+++ b/src/main/java/me/skorrloregaming/Server.java
@@ -817,6 +817,7 @@ public class Server extends JavaPlugin implements Listener {
 		getCommand("balance").setExecutor(new BalanceCmd());
 		getCommand("pay").setExecutor(new PayCmd());
 		getCommand("suicide").setExecutor(new SuicideCmd());
+		getCommand("transport").setExecutor(new TransportCmd());
 	}
 
 	@Override

--- a/src/main/java/me/skorrloregaming/SolidStorage.java
+++ b/src/main/java/me/skorrloregaming/SolidStorage.java
@@ -97,6 +97,15 @@ public class SolidStorage {
 		c.save(invFile);
 	}
 
+	public static void saveInventoryFromArray(Player player, ItemStack[] contents, String data) throws Exception {
+		String folder = getDataFolder() + File.separator + "Inventory";
+		String file = player.getUniqueId().toString() + "_" + data + ".yml";
+		File invFile = new File(folder, file);
+		YamlConfiguration c = new YamlConfiguration();
+		c.set("inventory.content", contents);
+		c.save(invFile);
+	}
+
 	public static boolean restoreInventory(Player player, String data) {
 		String folder = getDataFolder() + File.separator + "Inventory";
 		String file = player.getUniqueId().toString() + "_" + data + ".yml";
@@ -111,6 +120,21 @@ public class SolidStorage {
 		} else {
 			System.out.println("SolidStorage: Failed to restore inventory to player " + player.getName());
 			return false;
+		}
+	}
+
+	public static ItemStack[] restoreInventoryToArray(Player player, String data) {
+		String folder = getDataFolder() + File.separator + "Inventory";
+		String file = player.getUniqueId().toString() + "_" + data + ".yml";
+		File invFile = new File(folder, file);
+		if (invFile.exists()) {
+			YamlConfiguration c = YamlConfiguration.loadConfiguration(invFile);
+			@SuppressWarnings("unchecked")
+			ItemStack[] content = ((List<ItemStack>) c.get("inventory.content")).toArray(new ItemStack[0]);
+			return content;
+		} else {
+			System.out.println("SolidStorage: Failed to restore inventory to player " + player.getName());
+			return null;
 		}
 	}
 

--- a/src/main/java/me/skorrloregaming/commands/TransportCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/TransportCmd.java
@@ -1,0 +1,51 @@
+package me.skorrloregaming.commands;
+
+import me.skorrloregaming.*;
+import me.skorrloregaming.impl.InventoryType;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+public class TransportCmd implements CommandExecutor {
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+		if (!(sender instanceof Player))
+			return true;
+		Player player = ((Player) sender);
+		if (Link$.getDonorRankId(player) > -3) {
+			player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_BREAK, 1, 1);
+			player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "Sorry, you need Redstone rank to use transport.");
+			player.performCommand("store");
+			return true;
+		}
+		int invSize = 36;
+		if (CraftGo.Player.isPocketPlayer(player))
+			invSize = 54;
+		if (args.length == 0) {
+			sender.sendMessage(Link$.Legacy.tag + ChatColor.GRAY + "Syntax " + ChatColor.RED + "/" + label + " <minigame>");
+			return true;
+		}
+		String minigame = args[0].toLowerCase();
+		ItemStack[] contents = SolidStorage.restoreInventoryToArray(player, minigame);
+		if (contents == null) {
+			sender.sendMessage(Link$.Legacy.tag + ChatColor.RED + "Failed. " + ChatColor.GRAY + "There is no inventory stored for that minigame.");
+			return true;
+		}
+		Inventory transportInventory = Bukkit.createInventory(new InventoryMenu(player, InventoryType.TRANSPORT, minigame), invSize);
+		for (int i = 0; i < contents.length; i++)
+			transportInventory.setItem(i, contents[i]);
+		player.playSound(player.getLocation(), Sound.BLOCK_CHEST_OPEN, 1, 1);
+		player.openInventory(transportInventory);
+		player.sendMessage(contents.length + ""); // TODO: Remove debug
+		return true;
+	}
+
+}

--- a/src/main/java/me/skorrloregaming/commands/TransportCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/TransportCmd.java
@@ -2,6 +2,7 @@ package me.skorrloregaming.commands;
 
 import me.skorrloregaming.*;
 import me.skorrloregaming.impl.InventoryType;
+import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -39,12 +40,11 @@ public class TransportCmd implements CommandExecutor {
 			sender.sendMessage(Link$.Legacy.tag + ChatColor.RED + "Failed. " + ChatColor.GRAY + "There is no inventory stored for that minigame.");
 			return true;
 		}
-		Inventory transportInventory = Bukkit.createInventory(new InventoryMenu(player, InventoryType.TRANSPORT, minigame), invSize);
+		Inventory transportInventory = Bukkit.createInventory(new InventoryMenu(player, InventoryType.TRANSPORT, minigame), invSize, "Inventory of " + player.getName() + " from " + WordUtils.capitalize(minigame));
 		for (int i = 0; i < contents.length; i++)
 			transportInventory.setItem(i, contents[i]);
 		player.playSound(player.getLocation(), Sound.BLOCK_CHEST_OPEN, 1, 1);
 		player.openInventory(transportInventory);
-		player.sendMessage(contents.length + ""); // TODO: Remove debug
 		return true;
 	}
 

--- a/src/main/java/me/skorrloregaming/commands/TransportCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/TransportCmd.java
@@ -37,7 +37,7 @@ public class TransportCmd implements CommandExecutor {
 		String minigame = args[0].toLowerCase();
 		ItemStack[] contents = SolidStorage.restoreInventoryToArray(player, minigame);
 		if (contents == null) {
-			sender.sendMessage(Link$.Legacy.tag + ChatColor.RED + "Failed. " + ChatColor.GRAY + "There is no inventory stored for that minigame.");
+			sender.sendMessage(Link$.Legacy.tag + ChatColor.RED + "Failed. " + ChatColor.GRAY + "There is nothing stored for that minigame.");
 			return true;
 		}
 		Inventory transportInventory = Bukkit.createInventory(new InventoryMenu(player, InventoryType.TRANSPORT, minigame), invSize, "Inventory of " + player.getName() + " from " + WordUtils.capitalize(minigame));

--- a/src/main/java/me/skorrloregaming/commands/TransportCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/TransportCmd.java
@@ -26,7 +26,7 @@ public class TransportCmd implements CommandExecutor {
 			player.performCommand("store");
 			return true;
 		}
-		int invSize = 36;
+		int invSize = 45;
 		if (CraftGo.Player.isPocketPlayer(player))
 			invSize = 54;
 		if (args.length == 0) {

--- a/src/main/java/me/skorrloregaming/impl/InventoryType.java
+++ b/src/main/java/me/skorrloregaming/impl/InventoryType.java
@@ -14,5 +14,6 @@ public class InventoryType {
 	public static final String SPAWNER_UPGRADES = "spawner_upgrades";
 	public static final String SPAWNER_SHOP = "spawner_shop";
 	public static final String WARNINGS = "warnings";
+	public static final String TRANSPORT = "transport";
 	public static final String TEMPORARY = "temporary";
 }

--- a/src/main/java/me/skorrloregaming/listeners/PlayerEventHandler.java
+++ b/src/main/java/me/skorrloregaming/listeners/PlayerEventHandler.java
@@ -2540,6 +2540,17 @@ public class PlayerEventHandler implements Listener {
 			return;
 		}
 		if (event.getInventory().getHolder() instanceof InventoryMenu)
+			if (((InventoryMenu) event.getInventory().getHolder()).getName().equals(InventoryType.TRANSPORT)) {
+				String transportMinigame = (String) ((InventoryMenu) event.getInventory().getHolder()).getData();
+				try {
+					SolidStorage.saveInventoryFromArray(player, Arrays.copyOf(event.getInventory().getContents(), 41), transportMinigame);
+					player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "Success. " + ChatColor.GRAY + "The transport has been completed.");
+				} catch (Exception e) {
+					e.printStackTrace();
+					player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "Failed. " + ChatColor.GRAY + "An error occurred during inventory save.");
+				}
+			}
+		if (event.getInventory().getHolder() instanceof InventoryMenu)
 			if (((InventoryMenu) event.getInventory().getHolder()).getName().equals(InventoryType.SKYFIGHT_TEAMS)) {
 				if (Server.getSkyfight().containsKey(player.getUniqueId())) {
 					Server.getSkyfight().get(player.getUniqueId()).setHasTeamSelectionGuiOpen(false);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,8 @@ softdepend: [AuthMe, ProtocolSupport, ProtocolLib, ProtocolSupportPocketStuff, G
 loadbefore: [ChestShop, Factions]
 api-version: 1.14
 commands:
+    transport:
+        description: Transport items between minigames with a donor rank
     verify:
         description: Verify your minecraft account on discord
     feed:


### PR DESCRIPTION
This PR adds a command to the server that allows notable donators to transport items between mini-games through the ease of a command. This is especially notable for being able to transfer stuff from shop on factions over to survival or related. This should be used sparingly and if it get's out of hand I will add a delay for using the command or possibly even limits all together. If any issues come of this, please reference this PR.