### PR TITLE
Gold economy/1.14

### DIFF
--- a/src/main/java/me/skorrloregaming/$.java
+++ b/src/main/java/me/skorrloregaming/$.java
@@ -48,7 +48,7 @@ public class $ {
 	public static String pricePrefix = ChatColor.RESET + "Purchase Price: " + ChatColor.RED + "$";
 	public static List<String> validMinigames = Arrays.asList(new String[]{"kitpvp", "factions", "survival", "skyfight", "creative", "skyblock", "prison", "dated"});
 	public static List<String> validStorageMinigames = Arrays.asList(new String[]{"kitpvp", "factions", "survival", "creative", "skyblock"});
-	public static List<String> validEconomyMinigames = Arrays.asList(new String[]{"kitpvp", "factions", "skyblock"});
+	public static List<String> validEconomyMinigames = Arrays.asList(new String[]{"kitpvp", "factions", "skyblock", "survival"});
 	public static List<String> validLocketteMinigames = Arrays.asList(new String[]{"skyblock", "factions"});
 	public static List<String> validStairSeatMinigames = Arrays.asList(new String[]{"creative", "skyblock", "factions"});
 	public static List<String> validTransportMinigames = Arrays.asList(new String[]{"skyblock", "factions", "survival"});

--- a/src/main/java/me/skorrloregaming/CustomRecipes.java
+++ b/src/main/java/me/skorrloregaming/CustomRecipes.java
@@ -19,7 +19,7 @@ public class CustomRecipes {
 	public static void loadRecipes() {
 		{
 			NamespacedKey key = new NamespacedKey(Server.getPlugin(), "shulker_box");
-			ShapedRecipe recipe = new ShapedRecipe(key, Link$.createMaterial(Material.WHITE_SHULKER_BOX));
+			ShapedRecipe recipe = new ShapedRecipe(key, Link$.createMaterial(Material.SHULKER_BOX));
 			recipe.shape("AAA", "ABA", "AAA");
 			recipe.setIngredient('A', Material.DIAMOND);
 			recipe.setIngredient('B', Material.ENDER_CHEST);

--- a/src/main/java/me/skorrloregaming/EconManager.java
+++ b/src/main/java/me/skorrloregaming/EconManager.java
@@ -3,13 +3,14 @@ package me.skorrloregaming;
 import me.skorrloregaming.impl.ServerMinigame;
 import me.skorrloregaming.scoreboard.DisposableScoreboard;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
 import java.util.UUID;
 
 public class EconManager {
-	public static final int MAX_CASH = 1_000_000_000;
-	public static final int MIN_CASH = 0;
+	public static final double MAX_CASH = 1_000_000_000.0;
+	public static final double MIN_CASH = 0.0;
 
 	private static void updateScoreboards(String subDomain, UUID id) {
 		Player player = Bukkit.getPlayer(id);
@@ -21,13 +22,13 @@ public class EconManager {
 			scoreboard.schedule(player);
 	}
 
-	public static void withdrawCash(UUID id, int amount, String subDomain, boolean updateScoreboard) {
+	public static void withdrawCash(UUID id, double amount, String subDomain, boolean updateScoreboard) {
 		if ($.validEconomyMinigames.contains(subDomain)) {
 			String path = "config." + id.toString() + ".balance." + subDomain;
 			if (!Server.getPlugin().getConfig().contains(path)) {
 				Server.getPlugin().getConfig().set(path, 0);
 			}
-			int value = Integer.parseInt(Server.getPlugin().getConfig().getString(path)) - amount;
+			double value = Double.parseDouble(Server.getPlugin().getConfig().getString(path)) - amount;
 			if (value < MIN_CASH)
 				value = MIN_CASH;
 			Server.getPlugin().getConfig().set(path, value + "");
@@ -37,21 +38,21 @@ public class EconManager {
 		}
 	}
 
-	public static void withdrawCash(UUID id, int amount, String subDomain) {
+	public static void withdrawCash(UUID id, double amount, String subDomain) {
 		withdrawCash(id, amount, subDomain, true);
 	}
 
-	public static void depositCash(UUID id, int amount, String subDomain) {
+	public static void depositCash(UUID id, double amount, String subDomain) {
 		depositCash(id, amount, subDomain, true);
 	}
 
-	public static void depositCash(UUID id, int amount, String subDomain, boolean updateScoreboard) {
+	public static void depositCash(UUID id, double amount, String subDomain, boolean updateScoreboard) {
 		if ($.validEconomyMinigames.contains(subDomain)) {
 			String path = "config." + id.toString() + ".balance." + subDomain;
 			if (!Server.getPlugin().getConfig().contains(path)) {
 				Server.getPlugin().getConfig().set(path, 0);
 			}
-			int value = Integer.parseInt(Server.getPlugin().getConfig().getString(path)) + amount;
+			double value = Double.parseDouble(Server.getPlugin().getConfig().getString(path)) + amount;
 			if (value > MAX_CASH)
 				value = MAX_CASH;
 			Server.getPlugin().getConfig().set(path, value + "");
@@ -61,35 +62,42 @@ public class EconManager {
 		}
 	}
 
-	public static int retrieveCash(UUID id, String subDomain) {
+	public static double retrieveCash(UUID id, String subDomain) {
 		if ($.validEconomyMinigames.contains(subDomain)) {
 			String path = "config." + id.toString() + ".balance." + subDomain;
 			if (!Server.getPlugin().getConfig().contains(path)) {
-				Server.getPlugin().getConfig().set(path, 0);
+				Server.getPlugin().getConfig().set(path, 0.0);
 			}
-			return Integer.parseInt(Server.getPlugin().getConfig().getString(path));
+			return Double.parseDouble(Server.getPlugin().getConfig().getString(path));
 		} else {
-			return 0;
+			return 0.0;
 		}
 	}
 
-	public static void withdrawCash(Player player, int amount, String subDomain) {
+	public static void withdrawCash(Player player, double amount, String subDomain) {
 		withdrawCash(player.getUniqueId(), amount, subDomain);
 	}
 
-	public static void depositCash(Player player, int amount, String subDomain) {
+	public static void depositCash(Player player, double amount, String subDomain) {
 		depositCash(player.getUniqueId(), amount, subDomain);
 	}
 
-	public static void withdrawCash(Player player, int amount, String subDomain, boolean updateScoreboard) {
+	public static void withdrawCash(Player player, double amount, String subDomain, boolean updateScoreboard) {
 		withdrawCash(player.getUniqueId(), amount, subDomain, updateScoreboard);
 	}
 
-	public static void depositCash(Player player, int amount, String subDomain, boolean updateScoreboard) {
+	public static void depositCash(Player player, double amount, String subDomain, boolean updateScoreboard) {
 		depositCash(player.getUniqueId(), amount, subDomain, updateScoreboard);
 	}
 
-	public static int retrieveCash(Player player, String subDomain) {
+	public static double retrieveCash(Player player, String subDomain) {
 		return retrieveCash(player.getUniqueId(), subDomain);
 	}
+
+	public static double getWorth(Material material, ServerMinigame minigame) {
+		if (Server.getPlugin().getConfig().contains("settings.economy.modifier." + minigame.toString() + "." + material.toString()))
+			return Server.getPlugin().getConfig().getDouble("settings.economy.modifier." + minigame.toString() + "." + material.toString());
+		return 0.0;
+	}
+
 }

--- a/src/main/java/me/skorrloregaming/Server.java
+++ b/src/main/java/me/skorrloregaming/Server.java
@@ -826,6 +826,8 @@ public class Server extends JavaPlugin implements Listener {
 		getCommand("pay").setExecutor(new PayCmd());
 		getCommand("suicide").setExecutor(new SuicideCmd());
 		getCommand("transport").setExecutor(new TransportCmd());
+		getCommand("deposit").setExecutor(new DepositCmd());
+		getCommand("withdraw").setExecutor(new WithdrawCmd());
 	}
 
 	@Override

--- a/src/main/java/me/skorrloregaming/SignShop.java
+++ b/src/main/java/me/skorrloregaming/SignShop.java
@@ -39,7 +39,7 @@ public class SignShop {
 		} else {
 			playShopTitlePopup(player, sign.getBlock());
 		}
-		int cash = EconManager.retrieveCash(player, subDomain);
+		double cash = EconManager.retrieveCash(player, subDomain);
 		String tag = $.getMinigameTag(subDomain);
 		String[] lines = sign.getLines();
 		for (int i = 0; i < lines.length; i++) {

--- a/src/main/java/me/skorrloregaming/commands/BalanceCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/BalanceCmd.java
@@ -19,7 +19,7 @@ public class BalanceCmd implements CommandExecutor {
 		if (!(sender instanceof Player))
 			return true;
 		Player player = ((Player) sender);
-		if (!Server.getKitpvp().contains(player.getUniqueId()) && !Server.getFactions().contains(player.getUniqueId()) && !Server.getSkyblock().contains(player.getUniqueId())) {
+		if (!Server.getKitpvp().contains(player.getUniqueId()) && !Server.getSurvival().contains(player.getUniqueId()) && !Server.getFactions().contains(player.getUniqueId()) && !Server.getSkyblock().contains(player.getUniqueId())) {
 			player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "This minigame prevents use of this command.");
 			return true;
 		}

--- a/src/main/java/me/skorrloregaming/commands/BalanceTopCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/BalanceTopCmd.java
@@ -23,7 +23,7 @@ public class BalanceTopCmd implements CommandExecutor {
 		if (!(sender instanceof Player))
 			return true;
 		Player player = ((Player) sender);
-		if (!Server.getKitpvp().contains(player.getUniqueId()) && !Server.getFactions().contains(player.getUniqueId()) && !Server.getSkyblock().contains(player.getUniqueId())) {
+		if (!Server.getKitpvp().contains(player.getUniqueId()) && !Server.getSurvival().contains(player.getUniqueId()) && !Server.getFactions().contains(player.getUniqueId()) && !Server.getSkyblock().contains(player.getUniqueId())) {
 			player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "This minigame prevents use of this command.");
 			return true;
 		}

--- a/src/main/java/me/skorrloregaming/commands/DepositCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/DepositCmd.java
@@ -1,0 +1,36 @@
+package me.skorrloregaming.commands;
+
+import me.skorrloregaming.*;
+import me.skorrloregaming.impl.InventoryType;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Sound;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public class DepositCmd implements CommandExecutor {
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+		if (!(sender instanceof Player))
+			return true;
+		Player player = ((Player) sender);
+		if (!Server.getSurvival().contains(player.getUniqueId())) {
+			player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "This minigame prevents use of this command.");
+			return true;
+		}
+		if (Server.getPlayersInCombat().containsKey(player.getUniqueId())) {
+			player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "You cannot use this command during combat.");
+			return true;
+		}
+		String subDomain = $.getMinigameDomain(player);
+		Inventory inv = Bukkit.createInventory(new InventoryMenu(player, InventoryType.DEPOSIT_ALL), 27);
+		player.playSound(player.getLocation(), Sound.BLOCK_CHEST_OPEN, 1, 1);
+		player.openInventory(inv);
+		return true;
+	}
+
+}

--- a/src/main/java/me/skorrloregaming/commands/PayCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/PayCmd.java
@@ -21,7 +21,7 @@ public class PayCmd implements CommandExecutor {
 		String tag = Link$.Legacy.tag;
 		if (sender instanceof Player) {
 			Player player = (Player) sender;
-			if (!Server.getKitpvp().contains(player.getUniqueId()) && !Server.getFactions().contains(player.getUniqueId()) && !Server.getSkyblock().contains(player.getUniqueId())) {
+			if (!Server.getKitpvp().contains(player.getUniqueId()) && !Server.getSurvival().contains(player.getUniqueId()) && !Server.getFactions().contains(player.getUniqueId()) && !Server.getSkyblock().contains(player.getUniqueId())) {
 				player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "This minigame prevents use of this command.");
 				return true;
 			}

--- a/src/main/java/me/skorrloregaming/commands/PayCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/PayCmd.java
@@ -38,7 +38,7 @@ public class PayCmd implements CommandExecutor {
 			sender.sendMessage(tag + ChatColor.RED + "Failed. " + ChatColor.GRAY + "The specified player could not be found.");
 			return true;
 		}
-		int amount = Integer.parseInt(args[1]);
+		double amount = Double.parseDouble(args[1]);
 		DecimalFormat formatter = new DecimalFormat("###,###,###,###,###");
 		if (sender.isOp()) {
 			EconManager.depositCash(targetPlayer, amount, subDomain);
@@ -48,7 +48,7 @@ public class PayCmd implements CommandExecutor {
 		} else if (sender instanceof Player) {
 			amount = Math.abs(amount);
 			Player player = (Player) sender;
-			int currentPlayerCash = EconManager.retrieveCash(player, subDomain);
+			double currentPlayerCash = EconManager.retrieveCash(player, subDomain);
 			if (currentPlayerCash >= amount) {
 				EconManager.withdrawCash(player, amount, subDomain);
 				EconManager.depositCash(targetPlayer, amount, subDomain);

--- a/src/main/java/me/skorrloregaming/commands/StatisticsCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/StatisticsCmd.java
@@ -35,7 +35,7 @@ public class StatisticsCmd implements CommandExecutor {
 		if (Server.getSkyblock().contains(player.getUniqueId())) {
 			int currentPlayerPlaced = $.Skyblock.getPlayerPlacedBlocks(targetPlayer);
 			int currentPlayerBroken = $.Skyblock.getPlayerBrokenBlocks(targetPlayer);
-			int currentPlayerCash = EconManager.retrieveCash(targetPlayer, "skyblock");
+			double currentPlayerCash = EconManager.retrieveCash(targetPlayer, "skyblock");
 			String tag = $.getMinigameTag("kitpvp");
 			player.sendMessage(tag + ChatColor.RESET + "/ Statistics for player " + ChatColor.YELLOW + targetPlayer.getName());
 			player.sendMessage(tag + ChatColor.RESET + "Current Balance: " + ChatColor.YELLOW + "$" + formatter.format(currentPlayerCash));
@@ -45,7 +45,7 @@ public class StatisticsCmd implements CommandExecutor {
 			int currentPlayerKills = $.Kitpvp.getPlayerKills(targetPlayer);
 			int currentPlayerDeaths = $.Kitpvp.getPlayerDeaths(targetPlayer);
 			int currentPlayerDPK = currentPlayerKills / 50;
-			int currentPlayerCash = EconManager.retrieveCash(targetPlayer, "kitpvp");
+			double currentPlayerCash = EconManager.retrieveCash(targetPlayer, "kitpvp");
 			String tag = $.getMinigameTag("kitpvp");
 			player.sendMessage(tag + ChatColor.RESET + "/ Statistics for player " + ChatColor.YELLOW + targetPlayer.getName());
 			player.sendMessage(tag + ChatColor.RESET + "Current Balance: " + ChatColor.YELLOW + "$" + formatter.format(currentPlayerCash));

--- a/src/main/java/me/skorrloregaming/commands/WithdrawCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/WithdrawCmd.java
@@ -15,6 +15,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.text.DecimalFormat;
+import java.util.HashMap;
 
 public class WithdrawCmd implements CommandExecutor {
 
@@ -47,20 +48,16 @@ public class WithdrawCmd implements CommandExecutor {
 		}
 		double cash = EconManager.retrieveCash(player, subDomain);
 		if (amount <= cash) {
-			int totalWithdraw = 0;
-			do {
-				ItemStack purchaseItem = new ItemStack(material, amount % 64);
-				EconManager.withdrawCash(player, amount % 64, subDomain);
-				player.getInventory().addItem(purchaseItem);
-				player.updateInventory();
-				totalWithdraw += amount % 64;
-				amount -= amount % 64;
-				if (player.getInventory().firstEmpty() == -1) {
-					player.sendMessage(tag + ChatColor.RED + "Inventory full. " + ChatColor.GRAY + "Empty some slots then try again.");
-					return true;
-				}
-			} while (amount > 64 || amount > 0);
-			player.sendMessage(tag + ChatColor.RED + "Success. " + ChatColor.GRAY + "Purchased " + ChatColor.RED + materialName + " x" + totalWithdraw + ChatColor.GRAY + " for " + ChatColor.RED + "$" + formatter.format(totalWithdraw));
+			ItemStack purchaseItem = new ItemStack(material, amount);
+			EconManager.withdrawCash(player, amount, subDomain);
+			HashMap<Integer, ItemStack> remaining = player.getInventory().addItem(purchaseItem);
+			player.updateInventory();
+			if (remaining.size() > 0) {
+				player.sendMessage(tag + ChatColor.RED + "Inventory full. " + ChatColor.GRAY + "Dropping the rest on the ground.");
+				for (ItemStack itm : remaining.values())
+					player.getWorld().dropItem(player.getEyeLocation(), itm);
+			}
+			player.sendMessage(tag + ChatColor.RED + "Success. " + ChatColor.GRAY + "Purchased " + ChatColor.RED + materialName + " x" + amount + ChatColor.GRAY + " for " + ChatColor.RED + "$" + formatter.format(amount));
 			return true;
 		}
 		player.sendMessage(tag + ChatColor.RED + "Failed. " + ChatColor.GRAY + "You do not have enough money.");

--- a/src/main/java/me/skorrloregaming/commands/WithdrawCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/WithdrawCmd.java
@@ -1,0 +1,70 @@
+package me.skorrloregaming.commands;
+
+import me.skorrloregaming.*;
+import me.skorrloregaming.impl.InventoryType;
+import me.skorrloregaming.impl.ServerMinigame;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.text.DecimalFormat;
+
+public class WithdrawCmd implements CommandExecutor {
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+		if (!(sender instanceof Player))
+			return true;
+		Player player = ((Player) sender);
+		if (!Server.getSurvival().contains(player.getUniqueId())) {
+			player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "This minigame prevents use of this command.");
+			return true;
+		}
+		if (Server.getPlayersInCombat().containsKey(player.getUniqueId())) {
+			player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "You cannot use this command during combat.");
+			return true;
+		}
+		String subDomain = $.getMinigameDomain(player);
+		ServerMinigame minigame = $.getCurrentMinigame(player);
+		String tag = $.getMinigameTag(player);
+		DecimalFormat formatter = new DecimalFormat("###,###,###,###,###");
+		Material material = Material.getMaterial(Server.getPlugin().getConfig().getString("settings.economy.base." + minigame.toString()));
+		String materialName = Link$.formatMaterial(material);
+		int amount = 1;
+		if (args.length > 0) {
+			try {
+				amount = Integer.parseInt(args[0]);
+			} catch (Exception ex) {
+				player.sendMessage(tag + ChatColor.RED + "Failed. " + ChatColor.GRAY + "Please specify a whole number to withdraw.");
+			}
+		}
+		double cash = EconManager.retrieveCash(player, subDomain);
+		if (amount >= cash) {
+			int totalWithdraw = 0;
+			do {
+				ItemStack purchaseItem = new ItemStack(material, amount % 64);
+				EconManager.withdrawCash(player, amount % 64, subDomain);
+				player.getInventory().addItem(purchaseItem);
+				player.updateInventory();
+				totalWithdraw += amount % 64;
+				amount -= amount % 64;
+				if (player.getInventory().firstEmpty() == -1) {
+					player.sendMessage(tag + ChatColor.RED + "Inventory full. " + ChatColor.GRAY + "Empty some slots then try again.");
+					return true;
+				}
+			} while (amount > 64 || amount > 0);
+			player.sendMessage(tag + ChatColor.RED + "Success. " + ChatColor.GRAY + "Purchased " + ChatColor.RED + materialName + " x" + totalWithdraw + ChatColor.GRAY + " for " + ChatColor.RED + "$" + formatter.format(totalWithdraw));
+			return true;
+		}
+		player.sendMessage(tag + ChatColor.RED + "Failed. " + ChatColor.GRAY + "You do not have enough money.");
+		return true;
+	}
+
+}

--- a/src/main/java/me/skorrloregaming/commands/WithdrawCmd.java
+++ b/src/main/java/me/skorrloregaming/commands/WithdrawCmd.java
@@ -46,7 +46,7 @@ public class WithdrawCmd implements CommandExecutor {
 			}
 		}
 		double cash = EconManager.retrieveCash(player, subDomain);
-		if (amount >= cash) {
+		if (amount <= cash) {
 			int totalWithdraw = 0;
 			do {
 				ItemStack purchaseItem = new ItemStack(material, amount % 64);

--- a/src/main/java/me/skorrloregaming/hooks/Votifier_Listener.java
+++ b/src/main/java/me/skorrloregaming/hooks/Votifier_Listener.java
@@ -74,13 +74,13 @@ public class Votifier_Listener implements Listener {
 				);
 				LinkServer.getInstance().getRedisMessenger().broadcast(RedisChannel.CHAT, new MapBuilder().message(message).build());
 			}
-			int balance2 = EconManager.retrieveCash(player.getUniqueId(), "kitpvp");
+			double balance2 = EconManager.retrieveCash(player.getUniqueId(), "kitpvp");
 			int ceil2 = (int) Math.ceil(balance2 / 25);
 			int amountEarned2 = (int) (50 + (ceil2 * 10));
-			int balance1 = EconManager.retrieveCash(player.getUniqueId(), "factions");
+			double balance1 = EconManager.retrieveCash(player.getUniqueId(), "factions");
 			int ceil1 = (int) Math.ceil(balance1 / 30);
 			int amountEarned1 = (int) (500 + (ceil1 * 4.125));
-			int balance3 = EconManager.retrieveCash(player.getUniqueId(), "skyblock");
+			double balance3 = EconManager.retrieveCash(player.getUniqueId(), "skyblock");
 			int ceil3 = (int) Math.ceil(balance3 / 30);
 			int amountEarned3 = (int) (500 + (ceil3 * 5));
 			amountEarned1 *= MODIFIER;

--- a/src/main/java/me/skorrloregaming/impl/InventoryType.java
+++ b/src/main/java/me/skorrloregaming/impl/InventoryType.java
@@ -5,6 +5,7 @@ public class InventoryType {
 	public static final String NULL = "null";
 	public static final String SERVER_SELECTOR = "server_selector";
 	public static final String SELL_ALL = "sell_all";
+	public static final String DEPOSIT_ALL = "deposit_all";
 	public static final String LA_SHOPPE = "la_shoppe";
 	public static final String CHEST = "chest";
 	public static final String SESSIONS = "sessions";

--- a/src/main/java/me/skorrloregaming/listeners/PlayerEventHandler.java
+++ b/src/main/java/me/skorrloregaming/listeners/PlayerEventHandler.java
@@ -2584,7 +2584,7 @@ public class PlayerEventHandler implements Listener {
 				}
 				if (totalWorth > 0.0) {
 					EconManager.depositCash(player, totalWorth, $.getMinigameDomain(player));
-					player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "Success. " + ChatColor.GRAY + "Deposited " + ChatColor.RED + "$" + formatter.format(totalWorth));
+					player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "Success. " + ChatColor.GRAY + "Deposited " + ChatColor.RED + "$" + formatter.format(totalWorth) + ChatColor.GRAY + " into bank account.");
 				}
 			}
 		if (event.getInventory().getHolder() instanceof InventoryMenu)

--- a/src/main/java/me/skorrloregaming/listeners/PlayerEventHandler.java
+++ b/src/main/java/me/skorrloregaming/listeners/PlayerEventHandler.java
@@ -2001,6 +2001,11 @@ public class PlayerEventHandler implements Listener {
 				}
 			}
 			if (event.getInventory().getHolder() instanceof InventoryMenu)
+				if (((InventoryMenu) event.getInventory().getHolder()).getName().equals(InventoryType.DEPOSIT_ALL)) {
+					if (EconManager.getWorth(event.getCurrentItem().getType(), minigame) == 0.0)
+						event.setCancelled(true);
+				}
+			if (event.getInventory().getHolder() instanceof InventoryMenu)
 				if (((InventoryMenu) event.getInventory().getHolder()).getName().equals(InventoryType.SELL_ALL)) {
 					String name = String.valueOf(((InventoryMenu) event.getInventory().getHolder()).getData());
 					Material material = null;
@@ -2104,7 +2109,7 @@ public class PlayerEventHandler implements Listener {
 										DecimalFormat formatter = new DecimalFormat("###,###,###,###,###");
 										String materialName = Link$.formatMaterial(event.getCurrentItem().getType());
 										String subDomain = $.getMinigameDomain(player);
-										int cash = EconManager.retrieveCash(player, subDomain);
+										double cash = EconManager.retrieveCash(player, subDomain);
 										String tag = $.getMinigameTag(player);
 										String enchantName = Link$.formatEnchantment(String.valueOf(enchant.getEnchantment().getKey().getKey().trim()), tier);
 										if (cash >= price) {
@@ -2174,7 +2179,7 @@ public class PlayerEventHandler implements Listener {
 										DecimalFormat formatter = new DecimalFormat("###,###,###,###,###");
 										String materialName = Link$.formatMaterial(event.getCurrentItem().getType());
 										String subDomain = $.getMinigameDomain(player);
-										int cash = EconManager.retrieveCash(player, subDomain);
+										double cash = EconManager.retrieveCash(player, subDomain);
 										String tag = $.getMinigameTag(player);
 										if (cash >= price * 2 && player.isSneaking()) {
 											amount = amount * 2;
@@ -2304,7 +2309,7 @@ public class PlayerEventHandler implements Listener {
 								String requiredBalanceStr = ChatColor.stripColor(meta.getDisplayName().substring(meta.getDisplayName().indexOf("$") + 1));
 								requiredBalanceStr = requiredBalanceStr.substring(0, requiredBalanceStr.indexOf(")"));
 								int requiredBalance = Integer.parseInt(requiredBalanceStr);
-								int currentBalance = EconManager.retrieveCash(player, $.getMinigameDomain(player));
+								double currentBalance = EconManager.retrieveCash(player, $.getMinigameDomain(player));
 								if (upgradeCount + 1 <= 4) {
 									if (currentBalance >= requiredBalance) {
 										EconManager.withdrawCash(player, requiredBalance, $.getMinigameDomain(player));
@@ -2352,7 +2357,7 @@ public class PlayerEventHandler implements Listener {
 								String requiredBalanceStr = ChatColor.stripColor(meta.getDisplayName().substring(meta.getDisplayName().indexOf("$") + 1));
 								requiredBalanceStr = requiredBalanceStr.substring(0, requiredBalanceStr.indexOf(")"));
 								int requiredBalance = Integer.parseInt(requiredBalanceStr);
-								int currentBalance = EconManager.retrieveCash(player, $.getMinigameDomain(player));
+								double currentBalance = EconManager.retrieveCash(player, $.getMinigameDomain(player));
 								if (upgradeCount + 1 <= $.Kitpvp.DONOR_MAX_UPGRADE_VALUE) {
 									if (upgradeCount + 1 > $.Kitpvp.DEFAULT_MAX_UPGRADE_VALUE) {
 										if (Link$.getDonorRankId(player) > -2) {
@@ -2425,7 +2430,7 @@ public class PlayerEventHandler implements Listener {
 				String tag = $.getMinigameTag(player);
 				EntityType entityType = CraftGo.MobSpawner.getStoredSpawnerItemEntityType(event.getCurrentItem());
 				int price = 0;
-				int cash = EconManager.retrieveCash(player, domain);
+				double cash = EconManager.retrieveCash(player, domain);
 				int amount = 1;
 				switch (entityType) {
 					case SKELETON:
@@ -2544,6 +2549,7 @@ public class PlayerEventHandler implements Listener {
 	public void onInventoryClose(InventoryCloseEvent event) {
 		Player player = (Player) event.getPlayer();
 		ServerMinigame minigame = $.getCurrentMinigame(player);
+		DecimalFormat formatter = new DecimalFormat("###,###,###,###,###");
 		if (event.getInventory().getType() == org.bukkit.event.inventory.InventoryType.ENCHANTING) {
 			EnchantingInventory inventory = (EnchantingInventory) event.getInventory();
 			inventory.setItem(1, Link$.createMaterial(Material.AIR));
@@ -2564,6 +2570,21 @@ public class PlayerEventHandler implements Listener {
 			if (((InventoryMenu) event.getInventory().getHolder()).getName().equals(InventoryType.SKYFIGHT_TEAMS)) {
 				if (Server.getSkyfight().containsKey(player.getUniqueId())) {
 					Server.getSkyfight().get(player.getUniqueId()).setHasTeamSelectionGuiOpen(false);
+				}
+			}
+		if (event.getInventory().getHolder() instanceof InventoryMenu)
+			if (((InventoryMenu) event.getInventory().getHolder()).getName().equals(InventoryType.DEPOSIT_ALL)) {
+				double totalWorth = 0.0;
+				for (ItemStack itm : event.getInventory().getContents()) {
+					if (!(itm == null)) {
+						double singleItemWorth = 0.0;
+						if ((singleItemWorth = EconManager.getWorth(itm.getType(), minigame)) > 0.0)
+							totalWorth += singleItemWorth * itm.getAmount();
+					}
+				}
+				if (totalWorth > 0.0) {
+					EconManager.depositCash(player, totalWorth, $.getMinigameDomain(player));
+					player.sendMessage($.getMinigameTag(player) + ChatColor.RED + "Success. " + ChatColor.GRAY + "Deposited " + ChatColor.RED + "$" + formatter.format(totalWorth));
 				}
 			}
 		if (event.getInventory().getHolder() instanceof InventoryMenu)
@@ -2606,7 +2627,6 @@ public class PlayerEventHandler implements Listener {
 						data = item.getData();
 					}
 				}
-				DecimalFormat formatter = new DecimalFormat("###,###,###,###,###");
 				int singleAmount = 1;
 				double singlePrice = $.getSinglePricing(amount, price);
 				String materialName = Link$.formatMaterial(material);

--- a/src/main/java/me/skorrloregaming/scoreboard/boards/Factions_StatisticsScoreboard.java
+++ b/src/main/java/me/skorrloregaming/scoreboard/boards/Factions_StatisticsScoreboard.java
@@ -28,7 +28,7 @@ public class Factions_StatisticsScoreboard implements DisposableScoreboard {
 		Hashtable<String, Integer> list = new Hashtable<String, Integer>();
 		int currentPlayerKills = $.Factions.getPlayerKills(player);
 		int currentPlayerDeaths = $.Factions.getPlayerDeaths(player);
-		int currentPlayerCash = EconManager.retrieveCash(player, "factions");
+		double currentPlayerCash = EconManager.retrieveCash(player, "factions");
 		FPlayer fplayer = FPlayers.getInstance().getByPlayer(player);
 		Faction faction = fplayer.getFaction();
 		list.put(ChatColor.GOLD + "■" + ChatColor.YELLOW + " Faction", 9);

--- a/src/main/java/me/skorrloregaming/scoreboard/boards/Kitpvp_StatisticsScoreboard.java
+++ b/src/main/java/me/skorrloregaming/scoreboard/boards/Kitpvp_StatisticsScoreboard.java
@@ -17,7 +17,7 @@ public class Kitpvp_StatisticsScoreboard implements DisposableScoreboard {
 		int currentPlayerKills = $.Kitpvp.getPlayerKills(player);
 		int currentPlayerDeaths = $.Kitpvp.getPlayerDeaths(player);
 		int currentPlayerDPK = currentPlayerKills / 50;
-		int currentPlayerCash = EconManager.retrieveCash(player, "kitpvp");
+		double currentPlayerCash = EconManager.retrieveCash(player, "kitpvp");
 		list.put(ChatColor.GOLD + "■" + ChatColor.YELLOW + " Statistics", 5);
 		list.put(ChatColor.GOLD + "│" + ChatColor.GRAY + " Balance: " + ChatColor.RESET + "$" + formatter.format(currentPlayerCash), 4);
 		list.put(ChatColor.GOLD + "│" + ChatColor.GRAY + " Kills: " + ChatColor.RESET + formatter.format(currentPlayerKills), 3);

--- a/src/main/java/me/skorrloregaming/scoreboard/boards/Skyblock_StatisticsScoreboard.java
+++ b/src/main/java/me/skorrloregaming/scoreboard/boards/Skyblock_StatisticsScoreboard.java
@@ -35,7 +35,7 @@ public class Skyblock_StatisticsScoreboard implements DisposableScoreboard {
 		}
 		int placedBlocks = $.Skyblock.getPlayerPlacedBlocks(player);
 		int brokenBlocks = $.Skyblock.getPlayerBrokenBlocks(player);
-		int currentPlayerCash = EconManager.retrieveCash(player, "skyblock");
+		double currentPlayerCash = EconManager.retrieveCash(player, "skyblock");
 		DecimalFormat formatter = new DecimalFormat("###,###,###,###,###");
 		Hashtable<String, Integer> list = new Hashtable<String, Integer>();
 		if (maxmembers > 0) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -38,11 +38,6 @@ settings:
                 GOLD_INGOT: 1
                 GOLD_NUGGET: 0.1111111111111111
                 GOLD_BLOCK: 9
-                IRON_INGOT: 0.5
-                IRON_NUGGET: 0.0555555555555556
-                IRON_BLOCK: 4.5
-                DIAMOND: 10
-                DIAMOND_BLOCK: 90
                 EMERALD: 2
                 EMERALD_BLOCK: 18
     customJoinMessage: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,6 +30,21 @@ settings:
     ranking:
         enable: true
         prefix: true
+    economy:
+        base:
+            SURVIVAL: 'GOLD_INGOT'
+        modifier:
+            SURVIVAL:
+                GOLD_INGOT: 1
+                GOLD_NUGGET: 0.1111111111111111
+                GOLD_BLOCK: 9
+                IRON_INGOT: 0.5
+                IRON_NUGGET: 0.0555555555555556
+                IRON_BLOCK: 4.5
+                DIAMOND: 10
+                DIAMOND_BLOCK: 90
+                EMERALD: 2
+                EMERALD_BLOCK: 18
     customJoinMessage: true
     customQuitMessage: true
     topVotersHttpServerPort: 2096

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,10 @@ softdepend: [AuthMe, ProtocolSupport, ProtocolLib, ProtocolSupportPocketStuff, G
 loadbefore: [ChestShop, Factions]
 api-version: 1.14
 commands:
+    deposit:
+        description: Deposit hard currency into your bank account
+    withdraw:
+        description: Withdraw hard currency from your bank account
     transport:
         description: Transport items between minigames with a donor rank
     verify:


### PR DESCRIPTION
This PR adds an official currency to the survival mini-game while also adding support for decimal precision in currency server wide to make way for more complex uses for currency on the server in the future. You can now type /deposit which brings up an inventory where you can deposit gold ingots, gold blocks, emeralds, and/or emerald blocks into your bank account with a set modifier in the config. To top it off you can also withdraw from your virtual bank account and get back gold ingots as hard currency for old fashioned trading. This shouldn't be needed however as /pay is now officially supported on survival as well as /balancetop. If any issues arise from this, please make sure to reference this PR.